### PR TITLE
Mainly addresses #3 (https://github.com/bminer/intel-hex.js/issues/3)…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ require("intel_hex").parse(data);
 The `parse` function takes 3 arguments:
 
 - `data` - Intel Hex file (string in ASCII format or Buffer Object)
-- `bufferSize` - the size of the Buffer containing the data (optional)
-- `addressOffset` - starting address offset (optional)
+- `bufferSize` - the size of the Buffer containing the data (optional), the data exceeding the buffer size will be discarded
+- `addressOffset` - starting address offset (optional), the data before the starting address will be discarded
 
 and returns an Object with the following properties:
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ A parser/writer for Intel HEX file format.
 require("intel_hex").parse(data);
 ```
 
-The `parse` function takes 2 arguments:
+The `parse` function takes 3 arguments:
 
 - `data` - Intel Hex file (string in ASCII format or Buffer Object)
 - `bufferSize` - the size of the Buffer containing the data (optional)
+- `addressOffset` - starting address offset (optional)
 
 and returns an Object with the following properties:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "intel-hex",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "A JavaScript parser/writer for Intel HEX file format.",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "intel-hex",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "A JavaScript parser/writer for Intel HEX file format.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
…. Adds the optional starting address offset parameter (e.g. microcontroller images) and limits the size of the buffer with the value of bufferSize. Prevents out of memory issues on low RAM machines since it only creates the buffer of the required size from the expected range.