### PR TITLE
Add TypeScript definitions to index.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 *.lock
+/lib

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # intel-hex.js
 
 A parser/writer for Intel HEX file format.
+> This fork updates the package to use ES6 modules & TypeScript definitions.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# intel-hex.js
+# intel-hex.ts
 
 A parser/writer for Intel HEX file format.
 > This fork updates the package to use ES6 modules & TypeScript definitions.
 
+## Installation
+With `yarn`:
+```bash
+$ yarn add git+https://github.com/realjoshuau/intel-hex.ts.git
+```
+
 ## Usage
 
 ```js
-require("intel_hex").parse(data);
+import { parse } from "intel-hex.ts";
 ```
 
 The `parse` function takes 2 arguments:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # intel-hex.ts
 
-A parser/writer for Intel HEX file format.
+A typescript-based parser/writer for the Intel Hex file format.
 > This fork updates the package to use ES6 modules & TypeScript definitions.
 
 ## Installation
@@ -12,7 +12,7 @@ $ yarn add git+https://github.com/realjoshuau/intel-hex.ts.git
 ## Usage
 
 ```js
-import { parse } from "intel-hex.ts";
+import { parse } from "intel-hex.ts"; // The module itself is named `intel-hex.ts`
 ```
 
 The `parse` function takes 2 arguments:
@@ -29,4 +29,4 @@ and returns an Object with the following properties:
 - `startLinearAddress` - the address provided by the last
   start linear address record; null, if not given
 
-Special thanks to: http://en.wikipedia.org/wiki/Intel_HEX
+Special thanks to: http://en.wikipedia.org/wiki/Intel_HEX and [bminer/intel-hex.js](https://github.com/bminer/intel-hex.js)

--- a/index.ts
+++ b/index.ts
@@ -30,7 +30,7 @@ type IntelHex = {
 	startLinearAddress: number | null
 }
 
-export function parse(data: String | Buffer, bufferSize: number): IntelHex {
+export function parse(data: String | Buffer, bufferSize?: number): IntelHex {
 	if(data instanceof Buffer){
 		data = data.toString("ascii");
 	}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
 	"name": "intel-hex.ts",
 	"version": "0.1.2",
 	"description": "A TypeScript parser/writer for Intel HEX file format.",
-	"main": "index.ts",
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"build": "tsc",
+		"prepare": "npm run build"
 	},
 	"repository": {
 		"type": "git",
@@ -17,10 +20,12 @@
 		"reader",
 		"writer"
 	],
+	"files": ["lib/**/*"],
 	"author": "Blake Miner <miner.blake@gmail.com>",
 	"license": "MIT",
 	"readmeFilename": "README.md",
 	"devDependencies": {
-		"@types/node": "^18.15.11"
+		"@types/node": "^18.15.11",
+		"typescript": "^5.0.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
 	],
 	"author": "Blake Miner <miner.blake@gmail.com>",
 	"license": "MIT",
-	"readmeFilename": "README.md"
+	"readmeFilename": "README.md",
+	"devDependencies": {
+		"@types/node": "^18.15.11"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "intel-hex.ts",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "A TypeScript parser/writer for Intel HEX file format.",
 	"main": "index.ts",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-	"name": "intel-hex",
+	"name": "intel-hex.ts",
 	"version": "0.1.2",
-	"description": "A JavaScript parser/writer for Intel HEX file format.",
-	"main": "index.js",
+	"description": "A TypeScript parser/writer for Intel HEX file format.",
+	"main": "index.ts",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/bminer/intel-hex.js.git"
+		"url": "https://github.com/realjoshuau/intel-hex.ts.git"
 	},
 	"keywords": [
 		"intel",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "target": "es6",
+      "module": "commonjs",
+      "declaration": true,
+      "outDir": "./lib",
+      "strict": true
+    },
+    "include": ["index.ts"],
+    "exclude": ["node_modules", "**/__tests__/*"]
+}


### PR DESCRIPTION
Hello!
This PR adds TypeScript definitions for this project. (We're using intel-hex in a school club project.)
- Renames index.js -> index.ts
- Adds types to the `parse` function
- Replaces Record Type constants with an enum

Thank you so much for this library!